### PR TITLE
Win32 YAML problem fix

### DIFF
--- a/lib/CPAN/FTP.pm
+++ b/lib/CPAN/FTP.pm
@@ -21,6 +21,11 @@ $VERSION = "5.5005";
 sub _ftp_statistics {
     my($self,$fh) = @_;
     my $locktype = $fh ? LOCK_EX : LOCK_SH;
+    # XXX On Windows flock() implements mandatory locking, so we can
+    # XXX only use shared locking to still allow _yaml_load_file() to
+    # XXX read from the file using a different filehandle.
+    $locktype = LOCK_SH if $^O eq "MSWin32";
+
     $fh ||= FileHandle->new;
     my $file = File::Spec->catfile($CPAN::Config->{cpan_home},"FTPstats.yml");
     mkpath dirname $file;
@@ -56,6 +61,7 @@ sub _ftp_statistics {
             $CPAN::Frontend->mydie($@);
         }
     }
+    CPAN::_flock($fh, LOCK_UN);
     return $stats->[0];
 }
 


### PR DESCRIPTION
This commit contains changes found in the 1.9402 version of CPAN bundled with ActivePerl. It fixes the issue of YAML::XS not being able to access the FTPStats.yml file.
