### PR TITLE
2 fixes for 'cpan -D'

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -833,9 +833,10 @@ sub _show_Details
 	foreach my $arg ( @$args )
 		{
 		my $module = CPAN::Shell->expand( "Module", $arg );
-		my $author = CPAN::Shell->expand( "Author", $module->userid );
+		next unless $module;
 
-		next unless $module->userid;
+		my $author = CPAN::Shell->expand( "Author", $module->userid );
+		next unless $author;
 
 		print "$arg\n", "-" x 73, "\n\t";
 		print join "\n\t",


### PR DESCRIPTION
First commit fixes an uninitialized warning when 'cpan -D Number::Phone::FR' and Number::Phone::FR is not yet locally installed.

Second commit fixes a crash when 'cpan -D ' with a non existing module (exemple: cpan -D Number::Phone:XX )
