### PR TITLE
Update Metadata for META.{json,yml}

### DIFF
--- a/related/Bundle-CPAN/Makefile.PL
+++ b/related/Bundle-CPAN/Makefile.PL
@@ -57,6 +57,9 @@ my @sign = (MM->can("signature_target") ? (SIGN => 1) : ());
 WriteMakefile(
               NAME          => 'Bundle::CPAN',
               VERSION_FROM  => 'CPAN.pm',
+              LICENSE       => 'perl',
+              AUTHOR        => 'Andreas Koenig',
+              ABSTRACT      => 'Bundle to optimize the behaviour of CPAN.pm',
               @sign,
               dist => {
                        DIST_DEFAULT => join(" ",
@@ -73,6 +76,7 @@ WriteMakefile(
                (META_ADD => {
                              resources => {
                                  repository => "git://github.com/andk/cpanpm.git",
+                                 homepage   => "https://github.com/andk/cpanpm/tree/master/related/Bundle-CPAN"
                              },
                              keywords => ['CPAN','module','module installation'],
                             }) : ()),


### PR DESCRIPTION
I've set the license to "perl" in absense of a better suggestion,
  and set the path to the "homepage" to point to the sub-directory with
  this dist in it, in the hopes the next person who wants to touch this
  dist sees it easier.

Generation has been tested and the emitted .json/.yml files look ok.

Ideally, I'd have used the repository.web meta-2.0 attribute, but I
can't see a way to provide that to EUMM, everything I tried either broke
or broke.
