### PR TITLE
Support numerics in PAUSE IDs

### DIFF
--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -70,7 +70,7 @@ sub normalize {
     } elsif (
         $s =~ tr|/|| == 1
         or
-        $s !~ m|[A-Z]/[A-Z-]{2}/[A-Z-]{2,}/|
+        $s !~ m|[A-Z]/[A-Z-]{2}/[A-Z-0-9]{2,}/|
        ) {
         return $s if $s =~ m:^N/A|^Contact Author: ;
         $s =~ s|^(.)(.)([^/]*/)(.+)$|$1/$1$2/$1$2$3$4|;


### PR DESCRIPTION
Prior to this patch,

```
cpan -i IBMTORDB2/DBD-DB2-1.84.tar.gz
```

will end up trying to get I/I/I/IB/IBTORDB2/... because of double normalization.

As of today there are 4 PAUSE IDs with numbers in it: IBMTORDB2, P5P, PERL4LIB, WIN32
