### PR TITLE
Load META.yml not META.json in read_yaml

### DIFF
--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -3013,7 +3013,7 @@ sub read_meta {
 # XXX This should be DEPRECATED -- dagolden, 2011-02-05
 sub read_yaml {
     my($self) = @_;
-    my $meta_file = $self->pick_meta_file;
+    my $meta_file = $self->pick_meta_file('\.yml$');
     $self->debug("meta_file[$meta_file]") if $CPAN::DEBUG;
     return unless $meta_file;
     my $yaml;


### PR DESCRIPTION
With ETHER/MooseX-Storage-0.40, it doesn't pick up the correct dependencies (Test::CheckDeps) out of MYMETA files.

Here's what seems to be happening:
- CPAN.pm doesn't prefer META files, including MYMETA, if dynamic_config is true
- It falls back to META.yaml, however `pick_meta_file` could return MYMETA.json here, then parsing will fail

There's this "dynamic_config" check in multiple places, and I think MYMETA should be honored even when dynamic_config is true, instead of falling back to YAML _then_ honor it if its filename is MYMETA.

As noted in the comment, read_yaml() might need to be deprecated sooner.

However this fix should work as a band-aid to remedy the error here.
