### PR TITLE
Fix ANSI output on Windows.

### DIFF
--- a/lib/CPAN/FirstTime.pm
+++ b/lib/CPAN/FirstTime.pm
@@ -132,6 +132,9 @@ warnings, debugging output, and the output of the modules being
 installed. Set your favorite colors after some experimenting with the
 Term::ANSIColor module.
 
+Please note that on Windows platforms colorized output also requires
+the Win32::Console::ANSI module.
+
 Do you want to turn on colored output?
 
 =item colorize_print

--- a/lib/CPAN/Shell.pm
+++ b/lib/CPAN/Shell.pm
@@ -1434,6 +1434,14 @@ sub format_result {
     my $print_ornamented_have_warned = 0;
     sub colorize_output {
         my $colorize_output = $CPAN::Config->{colorize_output};
+        if ($colorize_output && $^O eq 'MSWin32' && !$CPAN::META->has_inst("Win32::Console::ANSI")) {
+            unless ($print_ornamented_have_warned++) {
+                # no myprint/mywarn within myprint/mywarn!
+                warn "Colorize_output is set to true but Win32::Console::ANSI is not
+installed. To activate colorized output, please install Win32::Console::ANSI.\n\n";
+            }
+            $colorize_output = 0;
+        }
         if ($colorize_output && !$CPAN::META->has_inst("Term::ANSIColor")) {
             unless ($print_ornamented_have_warned++) {
                 # no myprint/mywarn within myprint/mywarn!


### PR DESCRIPTION
There's the fine option to create colorized output in CPAN. This uses
the Term::ANSIColor module, which is in core since perl 5.6.0.

However on Windows, your typical 'cmd.exe' session can not display
colors all that well. For that, you must first load the
Win32::Console::ANSI module, which is not in core.

I added a check if this module is available (only if run on Windows)
and turn colors off if it is not. Also I extended the option text you
see when doing 'o conf init' to include a reference to the module.

This fixes RT48909 and its duplicate RT54931.

It's not even that I like colors on Windows so much, but I use Perl on Windows, and Activestate does use the colors somehow. If I uninstall ActiveState and use Strawberry with my old configuration, I see all the ANSI codes in my terminal which I find highly annoying.
