### PR TITLE
Let 'cpan -j' produce sorted configuration output.

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -965,6 +965,7 @@ sub _dump_config # -J
 
 	my $fh = $args->[0] || \*STDOUT;
 
+	local $Data::Dumper::Sortkeys = 1;
 	my $dd = Data::Dumper->new(
 		[$CPAN::Config],
 		['$CPAN::Config']


### PR DESCRIPTION
The 'cpan -j' option dumps the configuration of the CPAN client.
I found this to work OK but since perl 5.18 the sort order of the
configuration is different for every run. This is not so easy for
debugging. This patch turns on the sorting.
