### PR TITLE
Update Credentials.pm

### DIFF
--- a/lib/CPAN/HTTP/Credentials.pm
+++ b/lib/CPAN/HTTP/Credentials.pm
@@ -7,8 +7,8 @@ use vars qw($USER $PASSWORD $PROXY_USER $PROXY_PASSWORD);
 $CPAN::HTTP::Credentials::VERSION = $CPAN::HTTP::Credentials::VERSION = "1.9600";
 
 sub clear_credentials {
-   _clear_non_proxy_credentials();
-   _clear_proxy_credentials();
+   clear_non_proxy_credentials();
+   clear_proxy_credentials();
 }
 
 sub clear_non_proxy_credentials {


### PR DESCRIPTION
clear_credentials called undefined subroutines with leading underscores in their names. Removed the leading underscores to that it would call the two subroutines defined right below it.

This is a fix for RT ticket #91366.  
