### PR TITLE
fixing use of uninitialized value in concatenation and enhancing output in App/Cpan.pm

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -1157,9 +1157,9 @@ sub _show_Details
 		print "$arg\n", "-" x 73, "\n\t";
 		print join "\n\t",
 			$module->description ? $module->description : "(no description)",
-			$module->cpan_file,
-			$module->inst_file,
-			'Installed: ' . $module->inst_version,
+			$module->cpan_file ? $module->cpan_file : "(no cpanfile)",
+			$module->inst_file ? $module->inst_file :"(no installation file)" ,
+			'Installed: ' . ($module->inst_version ? $module->inst_version : "not installed"),
 			'CPAN:      ' . $module->cpan_version . '  ' .
 				($module->uptodate ? "" : "Not ") . "up to date",
 			$author->fullname . " (" . $module->userid . ")",


### PR DESCRIPTION
Fixing Use of uninitialized value in concatenation (.) or string at App/Cpan.pm line 1158.
Could be reproduced calling, for example:

```
cpan -D PAR::Packer                               
CPAN: Storable loaded ok (v2.45)
Reading '/home/mudler/.cpan/Metadata'
  Database was generated on Sun, 11 May 2014 22:53:02 GMT
PAR::Packer
-------------------------------------------------------------------------
Use of uninitialized value in concatenation (.) or string at App/Cpan.pm line 1158.
        (no description)
        R/RS/RSCHUPP/PAR-Packer-1.017.tar.gz
        CPAN:      1.017  Not up to date
        Roderich Schupp (RSCHUPP)
        rschupp@cpan.org
```

The patch will change the output like that

```
CPAN: Storable loaded ok (v2.45)
Reading '/home/mudler/.cpan/Metadata'
  Database was generated on Sun, 11 May 2014 22:53:02 GMT
PAR::Packer
-------------------------------------------------------------------------
        (no description)
        R/RS/RSCHUPP/PAR-Packer-1.017.tar.gz
        (no installation file)
        Installed: not installed
        CPAN:      1.017  Not up to date
        Roderich Schupp (RSCHUPP)
        rschupp@cpan.org
```

Adding also the "not installed" information
