### PR TITLE
CPAN::Meta::Requirements didn't add requirements_for_module until version 2.120920

### DIFF
--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -4,7 +4,7 @@ package CPAN::Distribution;
 use strict;
 use Cwd qw(chdir);
 use CPAN::Distroprefs;
-use CPAN::Meta::Requirements 2;
+use CPAN::Meta::Requirements 2.120920;
 use CPAN::InfoObj;
 use File::Path ();
 @CPAN::Distribution::ISA = qw(CPAN::InfoObj);


### PR DESCRIPTION
I ran into this on perl 5.6, and had to locally hack CPAN::Distribution to get modules to install.
