### PR TITLE
If $rtt is undef (or 0), don't multiply by it

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -859,9 +859,10 @@ sub _print_ping_report
 	my( $mirror ) = @_;
 
 	my $rtt = eval { _get_ping_report( $mirror ) };
+	my $result = $rtt ? sprintf "+ (%4d ms)", $rtt * 1000 : '!';
 
 	$logger->info(
-		sprintf "\t%s (%4d ms) %s", $rtt  ? '+' : '!',  $rtt * 1000, $mirror
+		sprintf "\t%s %s", $result, $mirror
 		);
 	}
 


### PR DESCRIPTION
If $rtt is undef or 0, just print '!', rather than '! (0 ms)',
since $rtt of undef would trigger warnings and the 0 ms wouldn't
be useful anyway.

(Noticed this when cpan -V printed a few warnings about $rtt being used when it's not defined)
