### PR TITLE
Bump $VERSION in modules changed since CPAN-2.00

### DIFF
--- a/lib/CPAN/Author.pm
+++ b/lib/CPAN/Author.pm
@@ -8,7 +8,7 @@ use CPAN::InfoObj;
 use vars qw(
             $VERSION
 );
-$VERSION = "5.5001";
+$VERSION = "5.5002";
 
 package CPAN::Author;
 use strict;

--- a/lib/CPAN/CacheMgr.pm
+++ b/lib/CPAN/CacheMgr.pm
@@ -10,7 +10,7 @@ use File::Find;
 use vars qw(
             $VERSION
 );
-$VERSION = "5.5001";
+$VERSION = "5.5002";
 
 package CPAN::CacheMgr;
 use strict;

--- a/lib/CPAN/FTP.pm
+++ b/lib/CPAN/FTP.pm
@@ -14,7 +14,7 @@ use vars qw($connect_to_internet_ok $Ua $Thesite $ThesiteURL $Themethod);
 use vars qw(
             $VERSION
 );
-$VERSION = "5.5005";
+$VERSION = "5.5006";
 
 #-> sub CPAN::FTP::ftp_statistics
 # if they want to rewrite, they need to pass in a filehandle

--- a/lib/CPAN/HTTP/Client.pm
+++ b/lib/CPAN/HTTP/Client.pm
@@ -6,7 +6,7 @@ use vars qw(@ISA);
 use CPAN::HTTP::Credentials;
 use HTTP::Tiny 0.005;
 
-$CPAN::HTTP::Client::VERSION = $CPAN::HTTP::Client::VERSION = "1.9600";
+$CPAN::HTTP::Client::VERSION = $CPAN::HTTP::Client::VERSION = "1.9601";
 
 # CPAN::HTTP::Client is adapted from parts of cpanm by Tatsuhiko Miyagawa
 # and parts of LWP by Gisle Aas

--- a/lib/CPAN/HandleConfig.pm
+++ b/lib/CPAN/HandleConfig.pm
@@ -12,7 +12,7 @@ CPAN::HandleConfig - internal configuration handling for CPAN.pm
 
 =cut 
 
-$VERSION = "5.5004"; # see also CPAN::Config::VERSION at end of file
+$VERSION = "5.5005"; # see also CPAN::Config::VERSION at end of file
 
 %can = (
         commit   => "Commit changes to disk",
@@ -769,7 +769,7 @@ sub prefs_lookup {
 
     use strict;
     use vars qw($AUTOLOAD $VERSION);
-    $VERSION = "5.5004";
+    $VERSION = "5.5005";
 
     # formerly CPAN::HandleConfig was known as CPAN::Config
     sub AUTOLOAD { ## no critic

--- a/lib/CPAN/Index.pm
+++ b/lib/CPAN/Index.pm
@@ -1,7 +1,7 @@
 package CPAN::Index;
 use strict;
 use vars qw($LAST_TIME $DATE_OF_02 $DATE_OF_03 $HAVE_REANIMATED $VERSION);
-$VERSION = "1.9600";
+$VERSION = "1.9601";
 @CPAN::Index::ISA = qw(CPAN::Debug);
 $LAST_TIME ||= 0;
 $DATE_OF_03 ||= 0;

--- a/lib/CPAN/LWP/UserAgent.pm
+++ b/lib/CPAN/LWP/UserAgent.pm
@@ -6,7 +6,7 @@ use vars qw(@ISA $USER $PASSWD $SETUPDONE);
 use CPAN::HTTP::Credentials;
 # we delay requiring LWP::UserAgent and setting up inheritance until we need it
 
-$CPAN::LWP::UserAgent::VERSION = $CPAN::LWP::UserAgent::VERSION = "1.9600";
+$CPAN::LWP::UserAgent::VERSION = $CPAN::LWP::UserAgent::VERSION = "1.9601";
 
 
 sub config {

--- a/lib/CPAN/Mirrors.pm
+++ b/lib/CPAN/Mirrors.pm
@@ -34,7 +34,7 @@ CPAN::Mirrors - Get CPAN mirror information and select a fast one
 package CPAN::Mirrors;
 use strict;
 use vars qw($VERSION $urllist $silent);
-$VERSION = "1.9600";
+$VERSION = "1.9601";
 
 use Carp;
 use FileHandle;


### PR DESCRIPTION
These $VERSION bumps are necessary to keep bleadperl's
Porting/cmpVERSION.pl script happy when comparing either current blead
or current maint-5.20 against perl-5.18.4. blead and maint-5.20 both have
CPAN-2.05; 5.18-4 has CPAN-2.00. These modules have changed, but their
$VERSION numbers have not.