### PR TITLE
RT 103099: Print logging init message to STDERR, for now

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -555,7 +555,7 @@ sub _init_logger
 
     unless( $log4perl_loaded )
         {
-        print "Loading internal null logger. Install Log::Log4perl for logging messages\n";
+        print STDERR "Loading internal null logger. Install Log::Log4perl for logging messages\n";
         $logger = Local::Null::Logger->new;
         return $logger;
         }


### PR DESCRIPTION
There needs to be a better way to do this. Some
things, such as the -J switch, need to completely
control STDOUT.