### PR TITLE
- Fix warning thrown by the method run_preps_on_packagedir()

### DIFF
--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -465,7 +465,7 @@ sub run_preps_on_packagedir {
     my $builddir = $CPAN::META->{cachemgr}->dir; # unsafe meta access, ok
     $self->safe_chdir($builddir);
     $self->debug("Removing tmp-$$") if $CPAN::DEBUG;
-    File::Path::rmtree("tmp-$$");
+    File::Path::rmtree("tmp-$$") if -d "tmp-$$";
     unless (mkdir "tmp-$$", 0755) {
         $CPAN::Frontend->unrecoverable_error(<<EOF);
 Couldn't mkdir '$builddir/tmp-$$': $!


### PR DESCRIPTION
Hi,

The method run_preps_on_packagedir() in the package CPAN::Distribution throws the following warning during one of my dependency test as below:

t/01-dependencies.t .. 14/34 
#   Failed test 'Map-Tube-London-0.74 passed all tests'
#   at t/01-dependencies.t line 14.
tmp-19640 for tmp-19640: No such file or directory at /usr/share/perl/5.10/CPAN/Distribution.pm line 468.

The line 468 looks like below:

    File::Path::rmtree("tmp-$$");
	
By adding simple check, we could avoid the warning:

    File::Path::rmtree("tmp-$$") if -d "tmp-$$";

Many Thanks.

Best Regards,
Mohammad S Anwar