### PR TITLE
Bug fix: Build.PL script_files may be non-ARRAY

### DIFF
--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -3421,8 +3421,21 @@ sub _exe_files {
     if (-f $buildparams) {
         CPAN->debug("Found '$buildparams'") if $CPAN::DEBUG;
         my $x = do $buildparams;
-        for my $sf (@{$x->[2]{script_files} || []}) {
-            push @exe_files, $sf;
+        for my $sf ($x->[2]{script_files}) {
+            if (my $reftype = ref $sf) {
+                if ($reftype eq "ARRAY") {
+                    push @exe_files, @$sf;
+                }
+                elsif ($reftype eq "HASH") {
+                    push @exe_files, keys %$sf;
+                }
+                else {
+                    $CPAN::Frontend->mywarn("Invalid reftype $reftype for Build.PL 'script_files'\n");
+                }
+            }
+            elsif (defined $sf) {
+                push @exe_files, $sf;
+            }
         }
     }
     return \@exe_files;


### PR DESCRIPTION
This bug was only triggered with enabled CPAN::Plugin::Specfile.

This happened with HTML-Tree's Build.PL, where 'script_files' is a SCALAR and not an array reference, as CPAN::Distribution expects:

> Catching error: "Can't use string (\"bin\") as an ARRAY ref while \"strict refs\" in use at ... lib/perl5/5.10.1/CPAN/Distribution.pm line 3466 ...
