### PR TITLE
Add "-f Makefile" to initial "make" (no args). Set PERL env var in "make test" and "make"

### DIFF
--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -2102,7 +2102,7 @@ is part of the perl-%s distribution. To install that, you need to run
         return;
     }
 
-    my $make = $self->{modulebuild} ? "Build" : "make";
+    my $make = $self->{modulebuild} ? "Build" : "make -f Makefile";
     $CPAN::Frontend->myprint(sprintf "Running %s for %s\n", $make, $self->id);
     local $ENV{PERL5LIB} = defined($ENV{PERL5LIB})
                            ? $ENV{PERL5LIB}
@@ -2162,7 +2162,13 @@ is part of the perl-%s distribution. To install that, you need to run
             }
             $system = join " ", $self->_build_command(), $CPAN::Config->{mbuild_arg};
         } else {
-            $system = join " ", $self->_make_command(),  $CPAN::Config->{make_arg};
+	    # ExtUtils::MakeMaker writes a file called Makefile. Explicitly use
+	    # that since GNU make can default to another name, e.g. GNUMakefile.
+	    # Note: -f is in the POSIX spec for make
+	    my @make_args = -f "Makefile" ?
+	      ($self->_make_command(), '-f', 'Makefile', $CPAN::Config->{make_arg}) :
+	      ($self->_make_command(), $CPAN::Config->{make_arg});
+            $system = join " ", @make_args;
         }
         $system =~ s/\s+$//;
         my $make_arg = $self->_make_phase_arg("make");

--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -2885,7 +2885,7 @@ sub unsat_prereq {
             } elsif (
                 $self->{reqtype} =~ /^(r|c)$/
                 && (exists $prereq_pm->{requires}{$need_module} || exists $prereq_pm->{opt_requires} )
-                && $nmo 
+                && $nmo
                 && !$inst_file
             ) {
                 # continue installing as a prereq; this may be a
@@ -3458,6 +3458,7 @@ sub test {
     # warn "XDEBUG: checking for notest: $self->{notest} $self";
     my $make = $self->{modulebuild} ? "Build" : "make";
 
+    local $ENV{PERL} = defined $ENV{PERL}? $ENV{PERL} : $^X;
     local $ENV{PERL5LIB} = defined($ENV{PERL5LIB})
                            ? $ENV{PERL5LIB}
                            : ($ENV{PERLLIB} || "");
@@ -3881,6 +3882,7 @@ sub install {
         return;
     }
 
+    local $ENV{PERL} = defined $ENV{PERL}? $ENV{PERL} : $^X;
     my $system;
     if (my $commandline = $self->prefs->{install}{commandline}) {
         $system = $commandline;


### PR DESCRIPTION
I tried also adding the same "-f Makefile" to "make install" but a test fails: 

```
$ blib/script/cpan -j t/97-lib_cpan1/CPAN/Config.pm Local::Make::Fails
Loading internal null logger. Install Log::Log4perl for logging messages
CPAN: Storable loaded ok (v2.53)
Reading '/src/external-vcs/github/rocky/cpanpm/cpan-home/Metadata'
Warning: Found only 11 objects in /src/external-vcs/github/rocky/cpanpm/cpan-home/Metadata
CPAN: LWP::UserAgent loaded ok (v6.13)
CPAN: Time::HiRes loaded ok (v1.9726)
CPAN: URI::URL loaded ok (v5.04)
Reading '/src/external-vcs/github/rocky/cpanpm/t/97-cpan1-test-mirror/authors/01mailrc.txt.gz'
CPAN: File::Which loaded ok (v1.19)
CPAN: Compress::Zlib loaded ok (v2.068)
............................................................................DONE
Reading '/src/external-vcs/github/rocky/cpanpm/t/97-cpan1-test-mirror/modules/02packages.details.txt'
  Database was generated on Tue, 27 Jan 2009 19:26:52 GMT
Warning: This index file is 2714 days old.
  Please check the host you chose as your CPAN mirror for staleness.
  I'll continue but problems seem likely to happen.
............................................................................DONE
Reading '/src/external-vcs/github/rocky/cpanpm/t/97-cpan1-test-mirror/modules/03modlist.data.gz'
DONE
Writing /src/external-vcs/github/rocky/cpanpm/cpan-home/Metadata
Running install for module 'Local::Make::Fails'
CPAN: Digest::SHA loaded ok (v5.95)
Checksum for /src/external-vcs/github/rocky/cpanpm/t/97-cpan1-test-mirror/authors/id/B/BU/BUSTER/Local-Make-Fails.tgz ok
CPAN: Archive::Tar loaded ok (v2.04)
Local-Make-Fails/
Local-Make-Fails/.gitignore
Local-Make-Fails/.releaserc
Local-Make-Fails/Makefile.PL
Local-Make-Fails/MANIFEST
'YAML' not installed, will not store persistent state
CPAN: CPAN::Meta::Requirements loaded ok (v2.132)
CPAN: CPAN::Meta loaded ok (v2.150001)
Configuring B/BU/BUSTER/Local-Make-Fails.tgz with Makefile.PL
I didn't work. Too bad for you! at Makefile.PL line 5.
Warning: No success on command[/home/rocky/perl5/perlbrew/perls/perl-5.22.0/bin/perl Makefile.PL INSTALL_BASE=/src/external-vcs/github/rocky/cpanpm/cpan-home]
  BUSTER/Local-Make-Fails.tgz
  /home/rocky/perl5/perlbrew/perls/perl-5.22.0/bin/perl Makefile.PL INSTALL_BASE=/src/external-vcs/github/rocky/cpanpm/cpan-home -- NOT OK
```

See also discussion in cpantesters.