### PR TITLE
cpan ignores -x option

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -625,6 +625,8 @@ sub _default
 	# How do I handle exit codes for multiple arguments?
 	my @errors = ();
 
+	$options->{x} or _disable_guessers();
+
 	foreach my $arg ( @$args )
 		{
 		# check the argument and perhaps capture typos
@@ -1517,13 +1519,18 @@ sub _expand_module
 	}
 
 my $guessers = [
-	[ qw( Text::Levenshtein::XS distance 7 ) ],
-	[ qw( Text::Levenshtein::Damerau::XS     xs_edistance 7 ) ],
+	[ qw( Text::Levenshtein::XS distance 7 1 ) ],
+	[ qw( Text::Levenshtein::Damerau::XS     xs_edistance 7 1 ) ],
 
-	[ qw( Text::Levenshtein     distance 7 ) ],
-	[ qw( Text::Levenshtein::Damerau::PP     pp_edistance 7 ) ],
+	[ qw( Text::Levenshtein     distance 7 1 ) ],
+	[ qw( Text::Levenshtein::Damerau::PP     pp_edistance 7 1 ) ],
 
 	];
+
+sub _disable_guessers
+	{
+	$_->[-1] = 0 for @$guessers;
+	}
 
 # for -x
 sub _guess_namespace
@@ -1561,6 +1568,7 @@ sub _guess_at_module_name
 		foreach my $try ( @$guessers ) {
 			my $can_guess = eval "require $try->[0]; 1" or next;
 
+			$try->[-1] or next; # disabled
 			no strict 'refs';
 			$distance = \&{ join "::", @$try[0,1] };
 			$threshold ||= $try->[2];

--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -1560,13 +1560,16 @@ sub _list_all_namespaces {
 
 BEGIN {
 my $distance;
+my $_threshold;
+my $can_guess;
+my $shown_help = 0;
 sub _guess_at_module_name
 	{
 	my( $target, $threshold ) = @_;
 
 	unless( defined $distance ) {
 		foreach my $try ( @$guessers ) {
-			my $can_guess = eval "require $try->[0]; 1" or next;
+			$can_guess = eval "require $try->[0]; 1" or next;
 
 			$try->[-1] or next; # disabled
 			no strict 'refs';
@@ -1574,12 +1577,23 @@ sub _guess_at_module_name
 			$threshold ||= $try->[2];
 			}
 		}
+	$_threshold ||= $threshold;
 
 	unless( $distance ) {
-		my $modules = join ", ", map { $_->[0] } @$guessers;
-		substr $modules, rindex( $modules, ',' ), 1, ', and';
+		unless( $shown_help ) {
+			my $modules = join ", ", map { $_->[0] } @$guessers;
+			substr $modules, rindex( $modules, ',' ), 1, ', and';
 
-		$logger->info( "I can suggest names if you install one of $modules" );
+			# Should this be colorized?
+			if( $can_guess ) {
+				$logger->info( "I can suggest names if you provide the -x option on invocation." );
+				}
+			else {
+				$logger->info( "I can suggest names if you install one of $modules" );
+				$logger->info( "and you provide the -x option on invocation." );
+				}
+			$shown_help++;
+			}
 		return;
 		}
 
@@ -1589,7 +1603,7 @@ sub _guess_at_module_name
 	my %guesses;
 	foreach my $guess ( @$modules ) {
 		my $distance = $distance->( $target, $guess );
-		next if $distance > $threshold;
+		next if $distance > $_threshold;
 		$guesses{$guess} = $distance;
 		}
 


### PR DESCRIPTION
The cpan interface allows close matching on misspelled module names using
the -x option and and form of Text::Levenshtein is installed. That option
however is ignored and the guessing will take place always if any of these
modules is installed

$ time cpan App::Cpax
0.9 seconds

with Text::Levenshtein installed
$ time cpan App::Cpax
99.0 seconds

This is to disable the quessers when any of those guessers in installed

After this change (trimmed output):

$ time cpan Text::CSC_XS
Could not expand [Text::CSC_XS]. Check the module name.
Skipping Text::CSC_XS because I couldn't find a matching namespace.
0.820u 0.388s 0:01.21 99.1%     0+0k 0+16io 0pf+0w

$ time cpan -x Text::CSC_XS
Checking 168232 namespaces for close match suggestions
Text::CSV_XS
Text::CSV_PP
Test::CSS
Text::CSV2TXT
Text::CSV
Text::CSV::R
Text::CHM
Text::TOC
Text::Chart
Text::MeCab
114.100u 0.868s 1:55.02 99.9%   0+0k 560+55112io 2pf+0w