### PR TITLE
CPAN::Config use manual install as default for root

### DIFF
--- a/lib/CPAN/FirstTime.pm
+++ b/lib/CPAN/FirstTime.pm
@@ -846,7 +846,7 @@ sub init {
     ) {
         local $auto_config = 0; # We *must* ask, even under autoconfig
         local *_real_prompt;    # We *must* show prompt
-        my_prompt_loop(install_help => 'local::lib', $matcher,
+        my_prompt_loop(install_help => ( $> ==  0 ? 'manual' : 'local::lib' ), $matcher,
                    'local::lib|sudo|manual');
     }
     $CPAN::Config->{install_help} ||= ''; # Temporary to suppress warnings


### PR DESCRIPTION
'local::lib' seems to be a good default choice
for unprivileged users, but when cpan is run by
root we should consider using 'manual' as the default
option.