### PR TITLE
Avoid a warning when prompting install_help intro

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -681,7 +681,7 @@ sub _hook_into_CPANpm_report
 
 	*CPAN::Shell::myprint = sub {
 		my($self,$what) = @_;
-		$scalar .= $what;
+		$scalar .= $what if defined $what;
 		$self->print_ornamented($what,
 			$CPAN::Config->{colorize_print}||'bold blue on_white',
 			);

--- a/lib/CPAN/FirstTime.pm
+++ b/lib/CPAN/FirstTime.pm
@@ -1698,7 +1698,8 @@ sub my_prompt_loop {
     my $ans;
 
     if (!$auto_config && (!$m || $item =~ /$m/)) {
-        $CPAN::Frontend->myprint($prompts{$item . "_intro"});
+        my $intro = $prompts{$item . "_intro"};
+        $CPAN::Frontend->myprint($intro) if defined $intro;
         $CPAN::Frontend->myprint(" <$item>\n");
         do { $ans = prompt($prompts{$item}, $default);
         } until $ans =~ /$ok/;


### PR DESCRIPTION
Resolving #124

install_help does not have one intro and this would
raise a warning in some weird cases.