### PR TITLE
YAML modules default for $LoadBlessed was changed to false

### DIFF
--- a/lib/CPAN.pm
+++ b/lib/CPAN.pm
@@ -558,7 +558,9 @@ sub _yaml_loadfile {
         # 5.6.2 could not do the local() with the reference
         # so we do it manually instead
         my $old_loadcode = ${"$yaml_module\::LoadCode"};
+        my $old_loadblessed = ${"$yaml_module\::LoadBlessed"};
         ${ "$yaml_module\::LoadCode" } = $CPAN::Config->{yaml_load_code} || 0;
+        ${ "$yaml_module\::LoadBlessed" } = 1;
 
         my ($code, @yaml);
         if ($code = UNIVERSAL::can($yaml_module, "LoadFile")) {
@@ -582,6 +584,7 @@ sub _yaml_loadfile {
             }
         }
         ${"$yaml_module\::LoadCode"} = $old_loadcode;
+        ${"$yaml_module\::LoadBlessed"} = $old_loadblessed;
         return \@yaml;
     } else {
         # this shall not be done by the frontend


### PR DESCRIPTION
This will fix t/12cpan.t and t/31sessions.t
So I believe #132 is not necessary

I tested with YAML.pm 1.30 and YAML::Syck 1.32

See also https://rt.cpan.org/Ticket/Display.html?id=131602 and https://rt.cpan.org/Ticket/Display.html?id=131615