### PR TITLE
Consider Module::Build as undeclared prerequisite only if there are no configure phase prereqs declared

### DIFF
--- a/lib/CPAN/Distribution.pm
+++ b/lib/CPAN/Distribution.pm
@@ -2882,7 +2882,7 @@ sub prereqs_for_slot {
         }
         if (-f "Build.PL"
             && ! -f File::Spec->catfile($self->{build_dir},"Makefile.PL")
-            && ! $merged->requirements_for_module("Module::Build")
+            && ! @{[ $merged->required_modules ]}
             && ! $CPAN::META->has_inst("Module::Build")
            ) {
             $CPAN::Frontend->mywarn(


### PR DESCRIPTION
This brings it in line with cpanm's heuristic: https://metacpan.org/source/MIYAGAWA/Menlo-Legacy-1.9022/lib/Menlo/CLI/Compat.pm#L1971

The presence of a Build.PL by itself does not indicate that Module::Build is required (in particular, there are now many Module::Build::Tiny based Build.PLs), and a configure prereq will be added for any other Build.PL based installer.