### PR TITLE
"Promote" Module::Signature from Bundle::CPANxxl to Bundle::CPAN

### DIFF
--- a/related/Bundle-CPAN/CPAN.pm
+++ b/related/Bundle-CPAN/CPAN.pm
@@ -44,6 +44,8 @@ Module::Build -- needed by File::Spec
 
 File::Spec -- prereq
 
+Module::Signature
+
 Digest::SHA
 
 File::HomeDir

--- a/related/Bundle-CPAN/CPANxxl.pm
+++ b/related/Bundle-CPAN/CPANxxl.pm
@@ -29,8 +29,6 @@ Bundle::CPAN
 
 Module::Info
 
-Module::Signature
-
 CPAN::Reporter
 
 Kwalify
@@ -44,7 +42,7 @@ Module::Versions::Report
 =head1 DESCRIPTION
 
 This bundle includes Bundle::CPAN plus what I consider indispensible
-but not everybody can compile, namely Expect and Module::Signature.
+but not everybody can compile, namely Expect and YAML.
 
 I've taken the liberty to also add YAML::Syck because of its speed
 advantage.


### PR DESCRIPTION
Module::Signature is critical for validating signatures for downloaded CPAN modules; lacking enforced signatures or HTTPS support in CPAN, Perl installs don't know the provenance of the source codes they are downloading and installing on their systems. This is a small patch to "promote" Module::Signature from the XXL bundle to the regular one as step towards checking signatures systematically.

This PR is part of a larger effort to "Secure Perl" - comments welcome at https://docs.google.com/document/d/1DRkiCJhJu4RDI0u_JppBpFa0djouskxEyNHax912U_w/edit#