### PR TITLE
Change check_sigs to on by default

### DIFF
--- a/lib/CPAN/FirstTime.pm
+++ b/lib/CPAN/FirstTime.pm
@@ -142,10 +142,9 @@ author is not available or where some prerequisite for
 Module::Signature has a bug and so on.
 
 With the check_sigs parameter you can turn signature checking on and
-off. The default is off for now because the whole tool chain for the
-functionality is not yet considered mature by some. The author of
-CPAN.pm would recommend setting it to true most of the time and
-turning it off only if it turns out to be annoying.
+off. The default is on. The author of CPAN.pm would recommend setting
+it to true most of the time and turning it off only if it turns out to
+be annoying.
 
 Note that if you do not have Module::Signature installed, no signature
 checks will be performed at all.
@@ -959,7 +958,7 @@ sub init {
     #
     #= Module::Signature
     #
-    my_yn_prompt(check_sigs => 0, $matcher);
+    my_yn_prompt(check_sigs => 1, $matcher);
 
     #
     #= CPAN::Reporter


### PR DESCRIPTION
We should protect perl users out-of-the box by checking their module signatures unless they've told us otherwise.

When check_sigs was set to 0 for first time users 13 years ago, there was a concern that signature checking apparatus wasn't sufficiently mature. With more than a decade behind us, perhaps we could consider enabling this now as a sensible default.

If Module::Signature isn't installed, users are still able to install modules, just with a reminder to please install Module::Signature if they'd like to verify modules, so this change shouldn't exclude or break anyone.