### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 before_install:
    - sudo apt-get install -y liblog-log4perl-perl
+arch:
+   - amd64
+   - ppc64le
 language: perl
 perl:
    - '5.28'


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/cpanpm/builds/207689101 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!