### PR TITLE
2021 download must have SSL support

### DIFF
--- a/lib/CPAN/FTP.pm
+++ b/lib/CPAN/FTP.pm
@@ -400,7 +400,12 @@ sub hostdl_2021 {
     my($self, $base, $file, $aslocal) = @_; # the $aslocal is $aslocal_tempfile in the caller (old convention)
     my $proxy_vars = $self->_proxy_vars($base);
     my $url = "$base$file";
-    if ($CPAN::META->has_usable('HTTP::Tiny')) {
+    if (
+           ($CPAN::META->has_usable('HTTP::Tiny')
+            && $CPAN::META->has_usable('Net::SSLeay')
+            && $CPAN::META->has_usable('IO::Socket::SSL')
+           )
+    ){
         # mostly c&p from below
         require CPAN::HTTP::Client;
         my $chc = CPAN::HTTP::Client->new(


### PR DESCRIPTION
`localize_2021` checks for HTTP::Tiny+SSL support or curl/wget, but `hostdl_2021` only checks for the presence of HTTP::Tiny regardless of SSL support so it never falls back to curl/wget.  So if HTTP::Tiny is available but without SSL, and curl/wget is configured, CPAN will happily try HTTP::Tiny and fail to download from an `https` URL.

I've tested this change manually on a fresh box (where I discovered this) but someone should review it and do additional testing just in case I messed up the copy/paste somehow.