### PR TITLE
RT #107353 says that we need to ignore SIGWINCH

### DIFF
--- a/lib/CPAN.pm
+++ b/lib/CPAN.pm
@@ -14,7 +14,7 @@ BEGIN {
             $inc = File::Spec->rel2abs($inc) unless ref $inc;
         }
     }
-    $SIG{WINCH} = 'IGNORE' if exists $SIG{WINCH};
+    $SIG{WINCH} = 'IGNORE' unless defined $SIG{WINCH}; #RT 107353
 }
 use CPAN::Author;
 use CPAN::HandleConfig;


### PR DESCRIPTION
The previous change only ignored WINCH if that key existed in the %SIG hash. The Changes log entry from 2.14-TRIAL noted that setting this for systems that do not support WINCH could be noisy. I'm guessing that's the old Mac OS X.

If we don't mind old things complaining, we can always set it unless something got there first.

Or, let's add some notes about what concrete problems come up when we always set it.