### PR TITLE
Add verify_SSL=>1 to HTTP::Tiny in CPAN::HTTP::Client to verify https server identity

### DIFF
--- a/lib/CPAN/HTTP/Client.pm
+++ b/lib/CPAN/HTTP/Client.pm
@@ -32,6 +32,7 @@ sub mirror {
 
     my $want_proxy = $self->_want_proxy($uri);
     my $http = HTTP::Tiny->new(
+        verify_SSL => 1,
         $want_proxy ? (proxy => $self->{proxy}) : ()
     );
 


### PR DESCRIPTION
The `verify_SSL` flag is missing from `HTTP::Tiny`, and allows a network attacker to MITM the connection if it is used by the CPAN client.

~~Luckily, CPAN.pm seems to prefer `curl` (and maybe `wget`) over `HTTP::Tiny` when doing https. Those tools verify server identity by default.~~

Problem has been verified using [mitmproxy](https://docs.mitmproxy.org/stable/howto-transparent/) on CPAN v2.34

MITM test with fix
```
cpan[1]> reload index
Reading '/root/.cpan/Metadata'
  Database was generated on Tue, 28 Feb 2023 11:17:02 GMT
Fetching with HTTP::Tiny:
https://cpan.org/authors/01mailrc.txt.gz
HTTP::Tiny failed with an internal error: SSL connection failed for cpan.org: SSL connect attempt failed error:0A000086:SSL routines::certificate verify failed

Fetching with HTTP::Tiny:
https://cpan.org/modules/02packages.details.txt.gz
HTTP::Tiny failed with an internal error: SSL connection failed for cpan.org: SSL connect attempt failed error:0A000086:SSL routines::certificate verify failed

Fetching with HTTP::Tiny:
https://cpan.org/modules/03modlist.data.gz
HTTP::Tiny failed with an internal error: SSL connection failed for cpan.org: SSL connect attempt failed error:0A000086:SSL routines::certificate verify failed

```

MITM test without fix
```
cpan[1]> reload index
Reading '/root/.cpan/Metadata'
  Database was generated on Tue, 28 Feb 2023 11:17:02 GMT
Fetching with HTTP::Tiny:
https://cpan.org/authors/01mailrc.txt.gz
Reading '/root/.cpan/sources/authors/01mailrc.txt.gz'
............................................................................DONE
Fetching with HTTP::Tiny:
https://cpan.org/modules/02packages.details.txt.gz
Reading '/root/.cpan/sources/modules/02packages.details.txt.gz'
  Database was generated on Tue, 28 Feb 2023 11:17:02 GMT
  HTTP::Date not available
............................................................................DONE
Fetching with HTTP::Tiny:
https://cpan.org/modules/03modlist.data.gz
Reading '/root/.cpan/sources/modules/03modlist.data.gz'
DONE
Writing /root/.cpan/Metadata
```

