### PR TITLE
Makefile.PL - Fix INSTALLDIRS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -196,7 +196,7 @@ EOW
 }
 my @sign = (MM->can("signature_target") ? (SIGN => 1) : ());
 WriteMakefile(
-              INSTALLDIRS  => 'perl',  # as it is coming with perl
+              INSTALLDIRS  => ($] < 5.012) ? "perl" : "site",
               NAME         => 'CPAN',
               VERSION      => $version,
               EXE_FILES    => [qw(scripts/cpan scripts/cpan-mirrors)],


### PR DESCRIPTION
INSTALLDIRS should not be set to "perl" in perl versions newer than 5.12, because site will take precedence.