### PR TITLE
don't use an apostrophe in names

### DIFF
--- a/inc/Test/More.pm
+++ b/inc/Test/More.pm
@@ -18,7 +18,7 @@ sub _carp {
 
 require Exporter;
 use vars qw($VERSION @ISA @EXPORT %EXPORT_TAGS $TODO);
-$VERSION = '0.47';
+$VERSION = '0.47_01';
 @ISA    = qw(Exporter);
 @EXPORT = qw(ok use_ok require_ok
              is isnt like unlike is_deeply
@@ -89,7 +89,7 @@ sub isnt ($$;$) {
     $Test->isnt_eq(@_);
 }
 
-*isn't = \&isnt;
+*isn::t = \&isnt;
 
 
 


### PR DESCRIPTION
This was deprecated in 5.38 and has been removed in 5.41.3 in preparation for 5.42.

Changing the binding to use "isn::t" instead of just removing it allows this to continue to work with older perls if needed.

Fixes https://github.com/Perl/perl5/issues/22508