### PR TITLE
suppress warnings in VERSION discovery (#197)

### DIFF
--- a/lib/App/Cpan.pm
+++ b/lib/App/Cpan.pm
@@ -1481,6 +1481,7 @@ sub _eval_version
 		package
 		  ExtUtils::MakeMaker::_version;
 
+        no warnings;
 		local $sigil$var;
 		\$$var=undef; do {
 			$line


### PR DESCRIPTION
While trying to pull out the `$VERSION` in `_eval_version`, there could be warnings. This just turns those off. If the values are not defined we should get the same answer.